### PR TITLE
times in evl csv are already UTC

### DIFF
--- a/ksvotes/models/early_voting_location.py
+++ b/ksvotes/models/early_voting_location.py
@@ -2,8 +2,7 @@
 from .base import TimeStampedModel
 from django.db import models, connection, transaction
 import csv
-from ksvotes.utils import ks_today, KS_TZ
-from dateutil.parser import parse
+from ksvotes.utils import ks_today
 
 
 class FutureElectionManager(models.Manager):
@@ -55,7 +54,6 @@ class EarlyVotingLocation(TimeStampedModel):
         )
 
         locations = {}
-        tzinfos = {"CST": KS_TZ}
 
         with open(csv_file, newline="\n") as csvfile:
             next(csvfile)  # skip headers
@@ -83,8 +81,8 @@ class EarlyVotingLocation(TimeStampedModel):
                         evl.save()
                         locations[location_id] = evl
                     hours = EarlyVotingLocationHours(
-                        opens_at=parse(f"{row[12]} CST", tzinfos=tzinfos),
-                        closes_at=parse(f"{row[13]} CST", tzinfos=tzinfos),
+                        opens_at=row[12],
+                        closes_at=row[13],
                         location=evl,
                     )
                     hours.save()


### PR DESCRIPTION
I originally thought the csv times were CST and so I was coercing them into UTC. But they are already UTC so that simplifies the import.