### PR TITLE
django 4.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ server:  ## starts app
 	@docker-compose up
 
 .PHONY: start
-start: server ## Alias for make server
+start: services-start ## Alias for make services-start
 
 .PHONY: setup
 setup: bootstrap ## sets up a project to be used for the first time
@@ -143,6 +143,10 @@ services-stop: ## stop dev services
 
 .PHONY: stop
 stop: services-stop ## Alias for make services-stop
+
+.PHONY: services-start
+services-start:
+	docker-compose up db redis
 
 .PHONY: fixtures
 fixtures: ## Load fixtures (inside container)

--- a/ksvotes/models/registrant.py
+++ b/ksvotes/models/registrant.py
@@ -121,19 +121,16 @@ class Registrant(TimeStampedModel):
         paginator = Paginator(queryset, 200)
         for page_number in paginator.page_range:
             page = paginator.page(page_number)
-            updates = []
             for r in page.object_list:
                 cls.redact(r)
-                updates.append(r)
-            cls.objects.bulk_update(
-                updates,
-                [
-                    "registration",
-                    "redacted_at",
-                    "identification_found",
-                    "ab_identification_found",
-                ],
-            )
+                r.save(
+                    update_fields=[
+                        "registration",
+                        "redacted_at",
+                        "identification_found",
+                        "ab_identification_found",
+                    ]
+                )
 
     def to_dict(self):
         return {

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django>4.0
+Django==4.2.0
 bumpversion
 dateparser
 django-db-geventpool

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==4.2.0
+Django>4.0
 bumpversion
 dateparser
 django-db-geventpool

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ dj-database-url==0.5.0
     # via environs
 dj-email-url==1.0.2
     # via environs
-django==4.1.10
+django==4.2.1
     # via
     #   -r requirements.in
     #   django-db-geventpool

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ dj-database-url==0.5.0
     # via environs
 dj-email-url==1.0.2
     # via environs
-django==4.2.1
+django==4.2
     # via
     #   -r requirements.in
     #   django-db-geventpool

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ dj-database-url==0.5.0
     # via environs
 dj-email-url==1.0.2
     # via environs
-django==4.2
+django==4.2.1
     # via
     #   -r requirements.in
     #   django-db-geventpool


### PR DESCRIPTION
we see a regression error in tests in #167 

the error is with `bulk_update` where the `reg.registration` is being set to the raw sql rather than the encrypted JSON string.

```
>>> reg.registration
'Cast(CASE WHEN <WhereNode: (AND: Exact(Col(ksvotes_registrant, ksvotes.Registrant.id), 83))> THEN Value(\'{"foo": "bar", "ab_identification": "[REDACTED]", "identification": "[REDACTED]", "signature_string": "[REDACTED]", "vr_form": "[REDACTED]", "ab_forms": "[REDACTED]"}\'), WHEN <WhereNode: (AND: Exact(Col(ksvotes_registrant, ksvotes.Registrant.id), 1))> THEN Value(\'{"name_first": "No", "name_middle": "Such", "name_last": "Person", "dob": "01/01/2000", "addr": "123 Main St", "city": "Nowhere", "state": "KS", "zip": "12345", "email": "nosuchperson@example.com", "phone": "555-555-1234", "identification": "[REDACTED]", "ab_identification": "[REDACTED]", "vr_form": "[REDACTED]", "ab_forms": "[REDACTED]", "signature_string": "[REDACTED]"}\'), ELSE Value(None))'
```

this PR downgrades to 4.2.0 to test if the regression is in 4.2.0 or 4.2.1