### PR TITLE
Deny all requests that end with .php

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,14 +84,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           ENV_NAME: ci
       - name: Install Chrome driver
-        run: |
-          google-chrome-stable --version
-          export CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
-          echo "CHROME_MAIN_VERSION=${CHROME_MAIN_VERSION}"
-          export CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
-          echo "CHROMEDRIVER_VERSION=${CHROMEDRIVER_VERSION}"
-          curl "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
-          unzip chromedriver_linux64.zip -d ~/bin
+        uses: nanasess/setup-chromedriver@v2
       - name: Run tests
         run: make ci-test
       - name: Browser tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,6 +89,7 @@ jobs:
           export CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
           echo "CHROME_MAIN_VERSION=${CHROME_MAIN_VERSION}"
           export CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
+          echo "CHROMEDRIVER_VERSION=${CHROMEDRIVER_VERSION}"
           curl "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
           unzip chromedriver_linux64.zip -d ~/bin
       - name: Run tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -85,7 +85,9 @@ jobs:
           ENV_NAME: ci
       - name: Install Chrome driver
         run: |
+          google-chrome-stable --version
           export CHROME_MAIN_VERSION=`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`
+          echo "CHROME_MAIN_VERSION=${CHROME_MAIN_VERSION}"
           export CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_MAIN_VERSION"`
           curl "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip" -O
           unzip chromedriver_linux64.zip -d ~/bin

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,6 +63,11 @@ http {
     # path for static files
     root /code/ksvotes/static;
 
+    # keep out all the kids
+    location ~ \.php$ {
+      deny all;
+    }
+
     # strip /static prefix from any direct links
     # otherwise we would proxy to gunicorn/django to serve
     location ~ ^/static(/.*)$ {

--- a/playwright/test_php_deny.py
+++ b/playwright/test_php_deny.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+def test_php_deny(page):
+    # all requests that end in .php should be denied
+    response = page.goto("/some/path/to/file.php")
+    assert response.status == 400

--- a/playwright/test_php_deny.py
+++ b/playwright/test_php_deny.py
@@ -2,4 +2,4 @@
 def test_php_deny(page):
     # all requests that end in .php should be denied
     response = page.goto("/some/path/to/file.php")
-    assert response.status == 400
+    assert response.status == 403


### PR DESCRIPTION
Since we don't have a PHP app, but bad actors poke at the server occasionally to see if they can find exploits, just deny all requests that end with .php and prevent hitting django completely.

Also fixes the CI step for installing chromedriver, since they switched the process upstream. Just use the github action instead and let someone else deal with the hassle of tracking upstream changes.