### PR TITLE
Fix CI actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: [3.10.18]
         node-version: [16.20]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -50,7 +50,7 @@ jobs:
         python-version: [3.10.18]
         node-version: [16.20]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -47,12 +47,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.8]
+        python-version: [3.10.18]
         node-version: [16.20]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.8]
+        python-version: [3.10.18]
         node-version: [16.20]
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM revolutionsystems/python:3.10.18-wee-lto-optimized as ksvotes
+FROM revolutionsystems/python:3.10.13-wee-lto-optimized as ksvotes
 
 # build ImageMagick with gslib for formfiller
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM revolutionsystems/python:3.10.13-wee-lto-optimized as ksvotes
+FROM revolutionsystems/python:3.10.18-wee-lto-optimized as ksvotes
 
 # build ImageMagick with gslib for formfiller
 USER root


### PR DESCRIPTION
GitHub actions stopped working due to us running an older version. Bump up the rev numbers to the latest for `setup-python` and `checkout` and use the latest Python 3.10.x version.