### PR TITLE
Fix hidden_field label bug

### DIFF
--- a/ksvotes/templatetags/wtf.py
+++ b/ksvotes/templatetags/wtf.py
@@ -37,7 +37,7 @@ def hidden_field(field):
         "html": field(**html_attrs),
         "errors": None,
         "help_text": None,
-        "label": None,
+        "label": "",
     }
 
 


### PR DESCRIPTION
The "hidden" form field had a `label` defined as `None` which Python was turning into a string `"None"`.

Instead, use an empty string `""` so nothing is rendered.