### PR TITLE
API for registrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,10 @@ migrate: ## Run db migrations (inside container)
 	wait-for-it -h $(DATABASE_HOST) -p 5432 -t 20
 	python manage.py migrate --noinput
 
+.PHONY: db
+db: ## Connect to local psql
+	@. ./.env; psql -U $${PGUSER} -h localhost
+
 .PHONY: migrations
 migrations:
 	python manage.py makemigrations ksvotes

--- a/ksvotes/urls.py
+++ b/ksvotes/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("ref", home.referring_org, name="home.ref_v2"),
     path("r/<refcode>/", home.referring_org_redirect, name="home.ref_v2_redirect"),
     path("api/total-processed/", home.api_total_processed, name="api.total_processed"),
+    path("api/registrations/", home.api_reg_complete, name="api.reg_complete"),
     path("demo/", home.demo, name="home.demo"),
     path("debug/", home.debug, name="home.debug"),
     path("terms/", home.terms, name="home.terms"),


### PR DESCRIPTION
Addresses #475 

Adds `/api/registrations/` endpoint with optional `start_date` param, which takes a `yyyy-mm-dd` string. Default is today - 30 days.

Will return registrations for start date till the end of its month. E.g. if start date was `2025-08-10` the end date would be `2025-08-31`.