### PR TITLE
add reg_lookup_time to RegistrantExporter fieldnames

### DIFF
--- a/ksvotes/services/registrant_exporter.py
+++ b/ksvotes/services/registrant_exporter.py
@@ -39,6 +39,7 @@ class RegistrantExporter:
             "identification_found",
             "ab_identification_found",
             "user_agent",
+            "reg_lookup_time",
             "r_ref",
             "r_name_first",
             "r_name_last",


### PR DESCRIPTION
The exporter is broken - looks like reg_lookup_time was added to the database but not to the export code. Adding it to the export to fix.